### PR TITLE
Implement Help Center: Submit a Request CRUD Logic #15

### DIFF
--- a/controllers/helpRequest.controller.js
+++ b/controllers/helpRequest.controller.js
@@ -1,0 +1,128 @@
+const { HelpRequest } = require('../models');
+const { helpRequestSchema } = require('../utils/validators');
+const logger = require('../utils/logger');
+const path = require('path');
+const fs = require('fs');
+
+// Create uploads directory if it doesn't exist
+const uploadDir = path.join(__dirname, '../uploads/help-requests');
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir, { recursive: true });
+}
+
+exports.createHelpRequest = async (req, res) => {
+  try {
+    // Validate text fields
+    const { error, value } = helpRequestSchema.validate(req.body);
+    if (error) {
+      logger.error(`Validation error: ${error.details[0].message}`);
+      return res.status(400).json({ error: error.details[0].message });
+    }
+
+    const { email, subject, message } = value;
+    let documentPath = null;
+
+    // Handle file upload if present
+    if (req.files && req.files.document) {
+      const file = req.files.document;
+      
+      // Validate file type and size
+      if (file.mimetype !== 'application/pdf') {
+        return res.status(400).json({ error: 'Only PDF files are allowed' });
+      }
+      if (file.size > 5 * 1024 * 1024) {
+        return res.status(400).json({ error: 'File size exceeds 5MB limit' });
+      }
+
+      // Generate unique filename
+      const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1e9);
+      const filename = uniqueSuffix + path.extname(file.name);
+      documentPath = path.join(uploadDir, filename);
+
+      // Save file
+      await file.mv(documentPath);
+    }
+
+    // Create help request
+    const helpRequest = await HelpRequest.create({
+      email,
+      subject,
+      message,
+      documentPath,
+      status: 'open',
+    });
+
+    logger.info(`New help request created: ${helpRequest.id}`);
+    res.status(201).json(helpRequest);
+  } catch (error) {
+    logger.error(`Error creating help request: ${error.message}`);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
+// Keep other CRUD operations (getAll, get, update, delete) the same as before
+
+// Get all help requests (admin only)
+exports.getAllHelpRequests = async (req, res) => {
+  try {
+    const helpRequests = await HelpRequest.findAll({
+      order: [['createdAt', 'DESC']],
+    });
+    res.json(helpRequests);
+  } catch (error) {
+    logger.error(`Error fetching help requests: ${error.message}`);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
+// Get a single help request
+exports.getHelpRequest = async (req, res) => {
+  try {
+    const helpRequest = await HelpRequest.findByPk(req.params.id);
+    if (!helpRequest) {
+      return res.status(404).json({ error: 'Help request not found' });
+    }
+    res.json(helpRequest);
+  } catch (error) {
+    logger.error(`Error fetching help request: ${error.message}`);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
+// Update a help request (admin only)
+exports.updateHelpRequest = async (req, res) => {
+  try {
+    const helpRequest = await HelpRequest.findByPk(req.params.id);
+    if (!helpRequest) {
+      return res.status(404).json({ error: 'Help request not found' });
+    }
+
+    const updates = {};
+    if (req.body.status) updates.status = req.body.status;
+    if (req.body.message) updates.message = req.body.message;
+
+    await helpRequest.update(updates);
+    logger.info(`Help request updated: ${helpRequest.id}`);
+    res.json(helpRequest);
+  } catch (error) {
+    logger.error(`Error updating help request: ${error.message}`);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
+// Delete a help request (admin only)
+exports.deleteHelpRequest = async (req, res) => {
+  try {
+    const helpRequest = await HelpRequest.findByPk(req.params.id);
+    if (!helpRequest) {
+      return res.status(404).json({ error: 'Help request not found' });
+    }
+
+    await helpRequest.destroy();
+    logger.info(`Help request deleted: ${req.params.id}`);
+    res.status(204).send();
+  } catch (error) {
+    logger.error(`Error deleting help request: ${error.message}`);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};

--- a/models/helpRequest.model.js
+++ b/models/helpRequest.model.js
@@ -1,0 +1,50 @@
+const { DataTypes } = require('sequelize');
+const  sequelize  = require('../config/db.config');
+
+const HelpRequest = sequelize.define('HelpRequest', {
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    primaryKey: true,
+  },
+  email: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    validate: {
+      isEmail: true,
+    },
+  },
+  subject: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    defaultValue: 'Vulnerability Report',
+  },
+  message: {
+    type: DataTypes.TEXT,
+    allowNull: false,
+    validate: {
+      len: [10, 256],
+    },
+  },
+  documentPath: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
+  status: {
+    type: DataTypes.ENUM('open', 'in_progress', 'resolved', 'closed'),
+    defaultValue: 'open',
+  },
+  createdAt: {
+    type: DataTypes.DATE,
+    defaultValue: DataTypes.NOW,
+  },
+  updatedAt: {
+    type: DataTypes.DATE,
+    defaultValue: DataTypes.NOW,
+  },
+}, {
+  tableName: 'help_requests',
+  timestamps: true,
+});
+
+module.exports = HelpRequest;

--- a/models/index.js
+++ b/models/index.js
@@ -7,6 +7,7 @@ const User = require('./user.model');
 const SupportTicket = require('./supportTicket.model');
 const ValidatorRanking = require('./validatorRanking.model');
 const Profile = require('./profile.model');
+const HelpRequest = require('./helpRequest.model');
 
 
 // Optionally define associations (if any)
@@ -49,6 +50,7 @@ module.exports = {
   SupportTicket,
   ValidatorRanking,
   Profile,
+  HelpRequest,
 };
 
 

--- a/routes/helpRequest.routes.js
+++ b/routes/helpRequest.routes.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const router = express.Router();
+const helpRequestController = require('../controllers/helpRequest.controller');
+
+// Public routes
+router.post('/', helpRequestController.createHelpRequest);
+
+// Admin routes (no auth for now)
+router.get('/', helpRequestController.getAllHelpRequests);
+router.get('/:id', helpRequestController.getHelpRequest);
+router.put('/:id', helpRequestController.updateHelpRequest);
+router.delete('/:id', helpRequestController.deleteHelpRequest);
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -26,6 +26,7 @@ const userRoutes = require("./routes/user.routes");
 const supportRoutes = require("./routes/support.routes");
 const validatorRankingRoutes = require('./routes/validatorRanking.routes');
 const profileRoutes = require('./routes/profile.routes');
+const helpRequestRoutes = require('./routes/helpRequest.routes');
 
 // Initialize express app
 const app = express();
@@ -56,6 +57,7 @@ app.use("/users", userRoutes);
 app.use("/support", supportRoutes);
 app.use('/api/validator-rankings', validatorRankingRoutes);
 app.use('/api', profileRoutes);
+app.use('/api/help-requests', helpRequestRoutes);
 
 // Default route
 app.get('/', (req, res) => {

--- a/tests/integration/helpRequest.test.js
+++ b/tests/integration/helpRequest.test.js
@@ -1,0 +1,65 @@
+const request = require('supertest');
+const { sequelize } = require('../../models');
+const app = require('../../server');
+const HelpRequest = require('../../models/helpRequest.model'); // Make sure to import the model correctly
+
+describe('Help Request API', () => {
+  beforeAll(async () => {
+    // Initialize database connection and sync models
+    await sequelize.authenticate();
+    await sequelize.sync({ force: true });
+  });
+
+  afterAll(async () => {
+    await sequelize.close();
+  });
+
+  describe('POST /api/help-requests', () => {
+    it('should create a new help request', async () => {
+      const helpRequestData = {
+        email: 'test@example.com',
+        subject: 'Test Subject',
+        message: 'This is a test message with sufficient length.'
+      };
+
+      const response = await request(app)
+        .post('/api/help-requests')
+        .send(helpRequestData);
+
+      expect(response.status).toBe(201);
+      expect(response.body).toHaveProperty('id');
+    });
+
+    it('should reject invalid email', async () => {
+      const helpRequestData = {
+        email: 'invalid-email',
+        subject: 'Test Subject',
+        message: 'This is a test message with sufficient length.'
+      };
+
+      const response = await request(app)
+        .post('/api/help-requests')
+        .send(helpRequestData);
+
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe('GET /api/help-requests', () => {
+    it('should retrieve all help requests', async () => {
+      // Create test data first using the actual model
+      await HelpRequest.create({
+        email: 'test2@example.com',
+        subject: 'Test Subject 2',
+        message: 'Another test message'
+      });
+
+      const response = await request(app)
+        .get('/api/help-requests');
+
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+      expect(response.body.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/utils/validators.js
+++ b/utils/validators.js
@@ -34,6 +34,21 @@ const validateWallet = (data) => {
   return walletSchema.validate(data, { abortEarly: false });
 };
 
+//help request
+const helpRequestSchema = Joi.object({
+  email: Joi.string().email().required(),
+  subject: Joi.string().default('Vulnerability Report'),
+  message: Joi.string().min(10).max(256).required(),
+});
+const documentSchema = Joi.object({
+  document: Joi.object({
+    mimetype: Joi.string().valid('application/pdf').required(),
+    size: Joi.number().max(5 * 1024 * 1024).required(), // 5MB max
+  }).unknown(true),
+});
+
 module.exports = {
-  validateWallet
+  validateWallet,
+  helpRequestSchema,
+  documentSchema,
 };


### PR DESCRIPTION
This PR adds the Help Request feature to the FortiChain platform, allowing users to:
- Submit new help requests via POST /api/help-requests
- Retrieve all help requests via GET /api/help-requests

## Changes Included
✅ Created HelpRequest model with validation  
✅ Implemented controller methods for create and list operations  
✅ Added integration tests covering success and error cases  
✅ Documented API endpoints  

## Testing
All tests pass successfully:
- Help Request API tests
- Existing integration tests

## Screenshots 

<img width="978" alt="Screenshot 2025-04-27 at 7 40 19 PM" src="https://github.com/user-attachments/assets/60dbed5f-a5cf-4fa9-8ea3-0c78c005b322" />

## Checklist
- [x] Code follows project conventions
- [x] Tests added/updated
- [x] Documentation updated

 closed #15 