### PR TITLE
Implement subscribe newsletter

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -14,6 +14,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 mod escrow;
 mod health_check;
+pub mod newsletter;
 mod project;
 mod support_ticket;
 mod transaction;
@@ -49,10 +50,11 @@ pub fn api_router(app_state: AppState) -> Router {
 
     Router::new()
         .merge(health_check::router())
-        .merge(transaction::router())
         .merge(project::router())
+        .merge(transaction::router())
         .merge(support_ticket::router())
         .merge(escrow::router())
+        .merge(newsletter::router())
         .layer(trace_layer)
         .layer(request_id_layer)
         .layer(propagate_request_id_layer)

--- a/src/http/newsletter/domain.rs
+++ b/src/http/newsletter/domain.rs
@@ -1,0 +1,7 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NewsletterSubscriber {
+    pub email: String,
+    pub name: String,
+}

--- a/src/http/newsletter/mod.rs
+++ b/src/http/newsletter/mod.rs
@@ -1,0 +1,9 @@
+pub mod domain;
+pub mod subscribe;
+
+use crate::AppState;
+use axum::Router;
+
+pub fn router() -> Router<AppState> {
+    Router::new().nest("/newsletter", subscribe::router())
+}

--- a/src/http/newsletter/subscribe.rs
+++ b/src/http/newsletter/subscribe.rs
@@ -1,0 +1,66 @@
+use axum::{
+    Json,
+    extract::State,
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{Router, post},
+};
+use garde::Validate;
+use serde::Deserialize;
+use sqlx::PgPool;
+use sqlx::types::Uuid;
+
+use crate::{AppState, Result, db::Db, http::newsletter::domain::NewsletterSubscriber};
+
+pub fn router() -> Router<AppState> {
+    Router::new().route("/subscribe", post(subscribe_handler))
+}
+
+#[derive(Debug, Deserialize, Validate)]
+pub struct SubscribeRequest {
+    #[garde(email)]
+    email: String,
+    #[garde(length(min = 2, max = 255))]
+    name: String,
+}
+
+#[tracing::instrument(
+    name = "Subscribe to newsletter",
+    skip(state, req),
+    fields(
+        subscriber_email = %req.email,
+        subscriber_name = %req.name
+    )
+)]
+pub async fn subscribe_handler(
+    state: State<AppState>,
+    Json(req): Json<SubscribeRequest>,
+) -> Result<impl IntoResponse> {
+    req.validate()?;
+    let subscriber = NewsletterSubscriber {
+        email: req.email,
+        name: req.name,
+    };
+
+    Db::add_subscriber(&state.db.pool, &subscriber).await?;
+
+    Ok(StatusCode::OK)
+}
+
+impl Db {
+    pub async fn add_subscriber(pool: &PgPool, subscriber: &NewsletterSubscriber) -> Result<Uuid> {
+        let result = sqlx::query!(
+            r#"
+            INSERT INTO newsletter_subscribers (email, name)
+            VALUES ($1, $2)
+            RETURNING id
+            "#,
+            subscriber.email,
+            subscriber.name
+        )
+        .fetch_one(pool)
+        .await?;
+
+        Ok(result.id)
+    }
+}

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -3,6 +3,7 @@ mod create_project;
 mod escrow;
 mod health_check;
 mod helpers;
+mod newsletter;
 mod projects;
 mod support_tickets;
 mod transaction;

--- a/tests/api/newsletter.rs
+++ b/tests/api/newsletter.rs
@@ -1,0 +1,67 @@
+use crate::helpers::TestApp;
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use fortichain_server::http::newsletter::domain::NewsletterSubscriber;
+use serde_json::json;
+
+#[tokio::test]
+async fn subscribe_returns_a_200_for_valid_form_data() {
+    // Arrange
+    let app = TestApp::new().await;
+
+    let body = json!({
+        "email": "test@example.com",
+        "name": "Test"
+    });
+    // Act
+    let req = Request::post("/newsletter/subscribe")
+        .header("Content-Type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+
+    let response = app.request(req).await;
+
+    // Assert
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let saved = sqlx::query_as!(
+        NewsletterSubscriber,
+        "SELECT email, name FROM newsletter_subscribers",
+    )
+    .fetch_one(&app.db.pool)
+    .await
+    .expect("Failed to fetch saved subscriber.");
+
+    assert_eq!(saved.email, "test@example.com");
+    assert_eq!(saved.name, "Test");
+}
+
+#[tokio::test]
+async fn subscribe_returns_a_400_when_data_is_missing() {
+    // Arrange
+    let app = TestApp::new().await;
+    let test_cases = vec![
+        (json!({"name": "Test"}), "missing the email"),
+        (json!({"email": "test@example.com"}), "missing the name"),
+        (json!({}), "missing both name and email"),
+    ];
+
+    for (invalid_body, error_message) in test_cases {
+        // Act
+        let req = Request::post("/newsletter/subscribe")
+            .header("Content-Type", "application/json")
+            .body(Body::from(invalid_body.to_string()))
+            .unwrap();
+        let response = app.request(req).await;
+
+        // Assert
+        assert_eq!(
+            response.status(),
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "The API did not fail with 422 Unprocessable Entity when the payload was {}.",
+            error_message
+        );
+    }
+}


### PR DESCRIPTION
This PR adds a complete newsletter subscription system to the application, allowing users to subscribe with their email and name through a REST API endpoint.

## Changes Made

### Backend Implementation
- **New Module Structure**: Created `src/http/newsletter/` module with organized submodules:
  - `domain.rs`: Contains the `NewsletterSubscriber` struct
  - `subscribe.rs`: Handles subscription logic and database operations
  - `mod.rs`: Module organization and routing

### API Endpoint
- **POST `/newsletter/subscribe`**: New endpoint for newsletter subscriptions
  - Accepts JSON payload with `email` and `name` fields
  - Validates email format and name length (2-255 characters)
  - Returns 200 OK on successful subscription
  - Returns 422 Unprocessable Entity for validation errors

## Testing
All tests pass and provide comprehensive coverage of the happy path and error scenarios. Run tests with:
```bash
cargo test
```

Closes #104 