### PR TITLE
Feature/reject report feedback

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -16,6 +16,7 @@ mod escrow;
 mod health_check;
 pub mod newsletter;
 mod project;
+mod report;
 mod support_ticket;
 mod transaction;
 mod types;
@@ -55,6 +56,7 @@ pub fn api_router(app_state: AppState) -> Router {
         .merge(escrow::router())
         .merge(newsletter::router())
         .merge(validator::router())
+        .merge(report::router())
         .layer(trace_layer)
         .layer(request_id_layer)
         .layer(propagate_request_id_layer)

--- a/src/http/report/domain.rs
+++ b/src/http/report/domain.rs
@@ -1,0 +1,70 @@
+use garde::Validate;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Serialize, Deserialize, Validate)]
+pub struct RejectReportRequest {
+    #[garde(skip)]
+    pub report_id: Uuid,
+    #[garde(custom(validate_rejection_reason))]
+    pub reason: String,
+    #[garde(ascii, length(max = 1000))]
+    pub validator_notes: Option<String>,
+    #[garde(custom(validate_starknet_address))]
+    pub validated_by: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RejectReportResponse {
+    pub message: String,
+    pub report_id: Uuid,
+    pub status: String,
+    pub reason: String,
+    pub validator_notes: Option<String>,
+    pub validated_by: String,
+    pub rejected_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+pub struct Report {
+    pub id: Uuid,
+    pub title: String,
+    pub project_id: Uuid,
+    pub body: String,
+    pub reported_by: String,
+    pub validated_by: Option<String>,
+    pub status: String, // Cast from enum to string in query
+    pub severity: Option<String>, // Cast from enum to string in query
+    pub allocated_reward: Option<sqlx::types::BigDecimal>, // Use BigDecimal for numeric fields
+    pub reason: Option<String>, // Cast from enum to string in query
+    pub validator_notes: Option<String>,
+    pub researcher_response: Option<String>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+pub fn validate_rejection_reason(reason: &str, _context: &()) -> garde::Result {
+    let valid_reasons = [
+        "duplicate_report",
+        "incomplete_information", 
+        "already_known",
+        "out_of_scope"
+    ];
+    
+    if valid_reasons.contains(&reason) {
+        Ok(())
+    } else {
+        Err(garde::Error::new("Invalid rejection reason"))
+    }
+}
+
+pub fn validate_starknet_address(address: &str, _context: &()) -> garde::Result {
+    if address.starts_with("0x")
+        && address.len() == 66
+        && address.chars().skip(2).all(|c| c.is_ascii_hexdigit())
+    {
+        Ok(())
+    } else {
+        Err(garde::Error::new("Invalid Starknet address"))
+    }
+}

--- a/src/http/report/mod.rs
+++ b/src/http/report/mod.rs
@@ -1,0 +1,14 @@
+mod domain;
+mod reject_report;
+
+use axum::{Router, routing::post};
+pub use domain::*;
+
+use crate::AppState;
+
+pub(crate) fn router() -> Router<AppState> {
+    Router::new().route(
+        "/report/reject",
+        post(reject_report::reject_report),
+    )
+} 

--- a/src/http/report/reject_report.rs
+++ b/src/http/report/reject_report.rs
@@ -1,0 +1,153 @@
+use crate::{
+    AppState, Error, Result,
+    http::report::{RejectReportRequest, RejectReportResponse, Report},
+};
+use axum::{Json, extract::State, http::StatusCode};
+use garde::Validate;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[tracing::instrument(name = "Reject Report", skip(state, request))]
+pub async fn reject_report(
+    State(state): State<AppState>,
+    Json(request): Json<RejectReportRequest>,
+) -> Result<(StatusCode, Json<RejectReportResponse>)> {
+    request.validate()?;
+
+    tracing::info!(
+        report_id = %request.report_id,
+        validated_by = %request.validated_by,
+        "Attempting to reject report"
+    );
+
+    // First, verify the report exists and is in a valid state for rejection
+    let report = get_report_by_id(&state.db.pool, &request.report_id).await?;
+
+    if report.is_none() {
+        tracing::warn!(
+            report_id = %request.report_id,
+            "Report not found"
+        );
+        return Err(Error::NotFound);
+    }
+
+    let report = report.unwrap();
+
+    // Check if the report is already rejected or in a final state
+    if report.status == "rejected" || report.status == "closed" {
+        tracing::warn!(
+            report_id = %request.report_id,
+            status = %report.status,
+            "Cannot reject report that is already in final state"
+        );
+        return Err(Error::Conflict);
+    }
+
+    // Verify the validator is authorized to reject this report
+    if let Some(assigned_validator) = &report.validated_by {
+        if assigned_validator != &request.validated_by {
+            tracing::warn!(
+                report_id = %request.report_id,
+                assigned_validator = %assigned_validator,
+                request_validator = %request.validated_by,
+                "Validator not authorized to reject this report"
+            );
+            return Err(Error::Forbidden);
+        }
+    }
+    // If no validator is assigned, any validator can reject (based on business logic)
+
+    // Perform the rejection
+    let rejection_time = chrono::Utc::now();
+    reject_report_in_db(
+        &state.db.pool,
+        &request.report_id,
+        &request.reason,
+        &request.validator_notes,
+        &request.validated_by,
+        &rejection_time,
+    )
+    .await?;
+
+    tracing::info!(
+        report_id = %request.report_id,
+        validated_by = %request.validated_by,
+        "Successfully rejected report"
+    );
+
+    Ok((
+        StatusCode::OK,
+        Json(RejectReportResponse {
+            message: "Report successfully rejected".to_string(),
+            report_id: request.report_id,
+            status: "rejected".to_string(),
+            reason: request.reason,
+            validator_notes: request.validator_notes,
+            validated_by: request.validated_by,
+            rejected_at: rejection_time,
+        }),
+    ))
+}
+
+async fn get_report_by_id(
+    pool: &PgPool,
+    report_id: &Uuid,
+) -> Result<Option<Report>> {
+    let report = sqlx::query_as::<_, Report>(
+        r#"
+        SELECT 
+            id, title, project_id, body, reported_by, validated_by,
+            status::text as status, 
+            severity::text as severity, 
+            allocated_reward, 
+            reason::text as reason, 
+            validator_notes,
+            researcher_response, 
+            created_at, 
+            updated_at
+        FROM research_report 
+        WHERE id = $1
+        "#,
+    )
+    .bind(report_id)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(report)
+}
+
+async fn reject_report_in_db(
+    pool: &PgPool,
+    report_id: &Uuid,
+    reason: &str,
+    validator_notes: &Option<String>,
+    validated_by: &str,
+    rejection_time: &chrono::DateTime<chrono::Utc>,
+) -> Result<()> {
+    let result = sqlx::query(
+        r#"
+        UPDATE research_report 
+        SET 
+            status = 'rejected'::report_status_type,
+            reason = $2::rejection_reason,
+            validator_notes = $3,
+            validated_by = $4,
+            updated_at = $5
+        WHERE id = $1
+        "#,
+    )
+    .bind(report_id)
+    .bind(reason)
+    .bind(validator_notes)
+    .bind(validated_by)
+    .bind(rejection_time)
+    .execute(pool)
+    .await?;
+
+    // Check if any rows were affected (report exists and was updated)
+    if result.rows_affected() == 0 {
+        return Err(Error::NotFound);
+    }
+
+    Ok(())
+}

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -5,6 +5,7 @@ mod health_check;
 mod helpers;
 mod newsletter;
 mod projects;
+mod report;
 mod support_tickets;
 mod transaction;
 mod validator;

--- a/tests/api/report.rs
+++ b/tests/api/report.rs
@@ -1,0 +1,456 @@
+use crate::helpers::{TestApp, generate_address};
+use axum::{body::Body, extract::Request, http::StatusCode};
+use serde_json::json;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn test_reject_report_success() {
+    let app = TestApp::new().await;
+    let db = &app.db;
+
+    // Create a test project first (using correct schema fields)
+    let project_id = Uuid::now_v7();
+    let project_wallet = generate_address();
+    
+    sqlx::query(
+        r#"
+        INSERT INTO projects (
+            id, name, description, contract_address, owner_address, contact_info, created_at
+        ) VALUES (
+            $1, 'Test Project', 'A test project for reports', $2, $2, 'test@example.com', now()
+        )
+        "#,
+    )
+    .bind(project_id)
+    .bind(&project_wallet)
+    .execute(&db.pool)
+    .await
+    .expect("Failed to insert test project");
+
+    // Create a test report
+    let report_id = Uuid::now_v7();
+    let researcher_wallet = generate_address();
+    let validator_wallet = generate_address();
+
+    sqlx::query(
+        r#"
+        INSERT INTO research_report (
+            id, title, project_id, body, reported_by, status, created_at
+        ) VALUES (
+            $1, 'Test Report', $2, 'This is a test report body with sufficient content to meet the minimum requirement of 50 characters.', $3, 'submitted', now()
+        )
+        "#,
+    )
+    .bind(report_id)
+    .bind(project_id)
+    .bind(&researcher_wallet)
+    .execute(&db.pool)
+    .await
+    .expect("Failed to insert test report");
+
+    // Prepare rejection request
+    let payload = json!({
+        "report_id": report_id,
+        "reason": "incomplete_information",
+        "validator_notes": "The report lacks sufficient technical details to assess the vulnerability.",
+        "validated_by": validator_wallet
+    });
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/report/reject")
+        .header("content-type", "application/json")
+        .body(Body::from(payload.to_string()))
+        .unwrap();
+
+    let res = app.request(req).await;
+    let status = res.status();
+
+    assert_eq!(status, StatusCode::OK);
+
+    // Verify the report has been rejected
+    let report_status = sqlx::query_scalar::<_, String>(
+        "SELECT status::text FROM research_report WHERE id = $1",
+    )
+    .bind(report_id)
+    .fetch_one(&db.pool)
+    .await
+    .expect("Failed to check report status");
+
+    assert_eq!(report_status, "rejected");
+
+    // Verify the rejection details
+    let report = sqlx::query!(
+        r#"
+        SELECT reason::text as reason, validator_notes, validated_by 
+        FROM research_report 
+        WHERE id = $1
+        "#,
+        report_id
+    )
+    .fetch_one(&db.pool)
+    .await
+    .expect("Failed to fetch rejected report");
+
+    assert_eq!(report.reason, Some("incomplete_information".to_string()));
+    assert_eq!(report.validator_notes, Some("The report lacks sufficient technical details to assess the vulnerability.".to_string()));
+    assert_eq!(report.validated_by, Some(validator_wallet));
+}
+
+#[tokio::test]
+async fn test_reject_report_not_found() {
+    let app = TestApp::new().await;
+    let non_existent_report_id = Uuid::now_v7();
+    let validator_wallet = generate_address();
+
+    let payload = json!({
+        "report_id": non_existent_report_id,
+        "reason": "duplicate_report",
+        "validator_notes": "This report duplicates an existing finding.",
+        "validated_by": validator_wallet
+    });
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/report/reject")
+        .header("content-type", "application/json")
+        .body(Body::from(payload.to_string()))
+        .unwrap();
+
+    let res = app.request(req).await;
+    let status = res.status();
+
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_reject_report_already_rejected() {
+    let app = TestApp::new().await;
+    let db = &app.db;
+
+    // Create a test project (using correct schema fields)
+    let project_id = Uuid::now_v7();
+    let project_wallet = generate_address();
+    
+    sqlx::query(
+        r#"
+        INSERT INTO projects (
+            id, name, description, contract_address, owner_address, contact_info, created_at
+        ) VALUES (
+            $1, 'Test Project', 'A test project for reports', $2, $2, 'test@example.com', now()
+        )
+        "#,
+    )
+    .bind(project_id)
+    .bind(&project_wallet)
+    .execute(&db.pool)
+    .await
+    .expect("Failed to insert test project");
+
+    // Create an already rejected report
+    let report_id = Uuid::now_v7();
+    let researcher_wallet = generate_address();
+    let validator_wallet = generate_address();
+
+    sqlx::query(
+        r#"
+        INSERT INTO research_report (
+            id, title, project_id, body, reported_by, status, reason, 
+            validator_notes, validated_by, created_at
+        ) VALUES (
+            $1, 'Already Rejected Report', $2, 'This report was already rejected. It contains sufficient content to meet the minimum requirement of 50 characters for the body field.', $3, 'rejected', 'duplicate_report', 'Already rejected', $4, now()
+        )
+        "#,
+    )
+    .bind(report_id)
+    .bind(project_id)
+    .bind(&researcher_wallet)
+    .bind(&validator_wallet)
+    .execute(&db.pool)
+    .await
+    .expect("Failed to insert already rejected report");
+
+    // Try to reject it again
+    let payload = json!({
+        "report_id": report_id,
+        "reason": "out_of_scope",
+        "validator_notes": "Trying to reject again.",
+        "validated_by": validator_wallet
+    });
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/report/reject")
+        .header("content-type", "application/json")
+        .body(Body::from(payload.to_string()))
+        .unwrap();
+
+    let res = app.request(req).await;
+    let status = res.status();
+
+    assert_eq!(status, StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn test_reject_report_unauthorized_validator() {
+    let app = TestApp::new().await;
+    let db = &app.db;
+
+    // Create a test project (using correct schema fields)
+    let project_id = Uuid::now_v7();
+    let project_wallet = generate_address();
+    
+    sqlx::query(
+        r#"
+        INSERT INTO projects (
+            id, name, description, contract_address, owner_address, contact_info, created_at
+        ) VALUES (
+            $1, 'Test Project', 'A test project for reports', $2, $2, 'test@example.com', now()
+        )
+        "#,
+    )
+    .bind(project_id)
+    .bind(&project_wallet)
+    .execute(&db.pool)
+    .await
+    .expect("Failed to insert test project");
+
+    // Create a report assigned to a specific validator
+    let report_id = Uuid::now_v7();
+    let researcher_wallet = generate_address();
+    let assigned_validator = generate_address();
+    let unauthorized_validator = generate_address();
+
+    sqlx::query(
+        r#"
+        INSERT INTO research_report (
+            id, title, project_id, body, reported_by, status, validated_by, created_at
+        ) VALUES (
+            $1, 'Assigned Report', $2, 'This report is assigned to a specific validator. It contains sufficient content to meet the minimum requirement of 50 characters for the body field.', $3, 'assigned', $4, now()
+        )
+        "#,
+    )
+    .bind(report_id)
+    .bind(project_id)
+    .bind(&researcher_wallet)
+    .bind(&assigned_validator)
+    .execute(&db.pool)
+    .await
+    .expect("Failed to insert assigned report");
+
+    // Try to reject with unauthorized validator
+    let payload = json!({
+        "report_id": report_id,
+        "reason": "already_known",
+        "validator_notes": "Unauthorized rejection attempt.",
+        "validated_by": unauthorized_validator
+    });
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/report/reject")
+        .header("content-type", "application/json")
+        .body(Body::from(payload.to_string()))
+        .unwrap();
+
+    let res = app.request(req).await;
+    let status = res.status();
+
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn test_reject_report_invalid_reason() {
+    let app = TestApp::new().await;
+    let db = &app.db;
+
+    // Create a test project (using correct schema fields)
+    let project_id = Uuid::now_v7();
+    let project_wallet = generate_address();
+    
+    sqlx::query(
+        r#"
+        INSERT INTO projects (
+            id, name, description, contract_address, owner_address, contact_info, created_at
+        ) VALUES (
+            $1, 'Test Project', 'A test project for reports', $2, $2, 'test@example.com', now()
+        )
+        "#,
+    )
+    .bind(project_id)
+    .bind(&project_wallet)
+    .execute(&db.pool)
+    .await
+    .expect("Failed to insert test project");
+
+    // Create a test report
+    let report_id = Uuid::now_v7();
+    let researcher_wallet = generate_address();
+    let validator_wallet = generate_address();
+
+    sqlx::query(
+        r#"
+        INSERT INTO research_report (
+            id, title, project_id, body, reported_by, status, created_at
+        ) VALUES (
+            $1, 'Test Report', $2, 'This is a test report body with sufficient content.', $3, 'submitted', now()
+        )
+        "#,
+    )
+    .bind(report_id)
+    .bind(project_id)
+    .bind(&researcher_wallet)
+    .execute(&db.pool)
+    .await
+    .expect("Failed to insert test report");
+
+    // Try to reject with invalid reason
+    let payload = json!({
+        "report_id": report_id,
+        "reason": "invalid_reason",
+        "validator_notes": "Invalid reason test.",
+        "validated_by": validator_wallet
+    });
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/report/reject")
+        .header("content-type", "application/json")
+        .body(Body::from(payload.to_string()))
+        .unwrap();
+
+    let res = app.request(req).await;
+    let status = res.status();
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_reject_report_invalid_validator_address() {
+    let app = TestApp::new().await;
+    let report_id = Uuid::now_v7();
+
+    let payload = json!({
+        "report_id": report_id,
+        "reason": "duplicate_report",
+        "validator_notes": "Test with invalid address.",
+        "validated_by": "invalid_address"
+    });
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/report/reject")
+        .header("content-type", "application/json")
+        .body(Body::from(payload.to_string()))
+        .unwrap();
+
+    let res = app.request(req).await;
+    let status = res.status();
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_reject_report_missing_fields() {
+    let app = TestApp::new().await;
+
+    let payload = json!({
+        // Missing required fields
+        "validator_notes": "Test missing fields."
+    });
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/report/reject")
+        .header("content-type", "application/json")
+        .body(Body::from(payload.to_string()))
+        .unwrap();
+
+    let res = app.request(req).await;
+    let status = res.status();
+
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
+async fn test_reject_report_without_notes() {
+    let app = TestApp::new().await;
+    let db = &app.db;
+
+    // Create a test project (using correct schema fields)
+    let project_id = Uuid::now_v7();
+    let project_wallet = generate_address();
+    
+    sqlx::query(
+        r#"
+        INSERT INTO projects (
+            id, name, description, contract_address, owner_address, contact_info, created_at
+        ) VALUES (
+            $1, 'Test Project', 'A test project for reports', $2, $2, 'test@example.com', now()
+        )
+        "#,
+    )
+    .bind(project_id)
+    .bind(&project_wallet)
+    .execute(&db.pool)
+    .await
+    .expect("Failed to insert test project");
+
+    // Create a test report
+    let report_id = Uuid::now_v7();
+    let researcher_wallet = generate_address();
+    let validator_wallet = generate_address();
+
+    sqlx::query(
+        r#"
+        INSERT INTO research_report (
+            id, title, project_id, body, reported_by, status, created_at
+        ) VALUES (
+            $1, 'Test Report', $2, 'This is a test report body with sufficient content.', $3, 'submitted', now()
+        )
+        "#,
+    )
+    .bind(report_id)
+    .bind(project_id)
+    .bind(&researcher_wallet)
+    .execute(&db.pool)
+    .await
+    .expect("Failed to insert test report");
+
+    // Reject without validator notes
+    let payload = json!({
+        "report_id": report_id,
+        "reason": "out_of_scope",
+        "validated_by": validator_wallet
+    });
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/report/reject")
+        .header("content-type", "application/json")
+        .body(Body::from(payload.to_string()))
+        .unwrap();
+
+    let res = app.request(req).await;
+    let status = res.status();
+
+    assert_eq!(status, StatusCode::OK);
+
+    // Verify the report was rejected without notes
+    let report = sqlx::query!(
+        r#"
+        SELECT status::text as status, reason::text as reason, validator_notes, validated_by 
+        FROM research_report 
+        WHERE id = $1
+        "#,
+        report_id
+    )
+    .fetch_one(&db.pool)
+    .await
+    .expect("Failed to fetch rejected report");
+
+    assert_eq!(report.status, Some("rejected".to_string()));
+    assert_eq!(report.reason, Some("out_of_scope".to_string()));
+    assert_eq!(report.validator_notes, None);
+    assert_eq!(report.validated_by, Some(validator_wallet));
+}


### PR DESCRIPTION
This  pull request implements validator's ability to reject submitted reports with feedback.

What’s Included
1. Sets status to rejected

2. Records rejection reason and optional notes

3. Assigns validated_by

4. Locks report from further edits after rejection